### PR TITLE
Make database URL relative

### DIFF
--- a/js/dbhelper.js
+++ b/js/dbhelper.js
@@ -8,8 +8,7 @@ class DBHelper {
    * Change this to restaurants.json file location on your server.
    */
   static get DATABASE_URL() {
-    const port = 8000 // Change this to your server port
-    return `http://localhost:${port}/data/restaurants.json`;
+    return '/data/restaurants.json';
   }
 
   /**


### PR DESCRIPTION
Allows app to run within HTTPS and on other hostnames.  Removes need to specify port on per-developer basis