### PR TITLE
Docs: Added note for windows systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Your project will be evaluated by a Udacity code reviewer according to the [Rest
 1. In this folder, start up a simple HTTP server to serve up the site files on your local computer. Python has some simple tools to do this, and you don't even need to know Python. For most people, it's already installed on your computer.
 
     * In a terminal, check the version of Python you have: `python -V`. If you have Python 2.x, spin up the server with `python -m SimpleHTTPServer 8000` (or some other port, if port 8000 is already in use.) For Python 3.x, you can use `python3 -m http.server 8000`. If you don't have Python installed, navigate to Python's [website](https://www.python.org/) to download and install the software.
-
+   * Note -  For Windows systems, Python 3.x by default is installed as `python`. To start a Python 3.x server, you can simply do `python -m http.server 8000`.
 2. With your server running, visit the site: `http://localhost:8000`, and look around for a bit to see what the current experience looks like.
 3. Explore the provided code, and start making a plan to implement the required features in three areas: responsive design, accessibility and offline use.
 4. Write code to implement the updates to get this site on its way to being a mobile-ready website.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Your project will be evaluated by a Udacity code reviewer according to the [Rest
 1. In this folder, start up a simple HTTP server to serve up the site files on your local computer. Python has some simple tools to do this, and you don't even need to know Python. For most people, it's already installed on your computer.
 
     * In a terminal, check the version of Python you have: `python -V`. If you have Python 2.x, spin up the server with `python -m SimpleHTTPServer 8000` (or some other port, if port 8000 is already in use.) For Python 3.x, you can use `python3 -m http.server 8000`. If you don't have Python installed, navigate to Python's [website](https://www.python.org/) to download and install the software.
-   * Note -  For Windows systems, Python 3.x by default is installed as `python`. To start a Python 3.x server, you can simply do `python -m http.server 8000`.
+   * Note -  For Windows systems, Python 3.x is installed as `python` by default. To start a Python 3.x server, you can simply enter `python -m http.server 8000`.
 2. With your server running, visit the site: `http://localhost:8000`, and look around for a bit to see what the current experience looks like.
 3. Explore the provided code, and start making a plan to implement the required features in three areas: responsive design, accessibility and offline use.
 4. Write code to implement the updates to get this site on its way to being a mobile-ready website.


### PR DESCRIPTION
I've seen many scholars as windows user stumbling upon this. Python 3.x in windows isnt installed as `python3` by default. So this PR address this ambiguity.